### PR TITLE
Add support for publishing RGB8 images

### DIFF
--- a/src/omronsentech_camera/stcamera_interface.cpp
+++ b/src/omronsentech_camera/stcamera_interface.cpp
@@ -553,8 +553,8 @@ namespace stcamera
             case StApi::StPFNC_Mono16: 
               encoding = sensor_msgs::image_encodings::MONO16; 
               break;
-            case StApi::StPFNC_BGR8:
-              encoding = sensor_msgs::image_encodings::BGR8;
+            case StApi::StPFNC_RGB8:
+              encoding = sensor_msgs::image_encodings::RGB8;
               break;
           }
           if (encoding.empty())

--- a/src/omronsentech_camera/stcamera_interface.cpp
+++ b/src/omronsentech_camera/stcamera_interface.cpp
@@ -553,6 +553,9 @@ namespace stcamera
             case StApi::StPFNC_Mono16: 
               encoding = sensor_msgs::image_encodings::MONO16; 
               break;
+            case StApi::StPFNC_BGR8:
+              encoding = sensor_msgs::image_encodings::BGR8;
+              break;
           }
           if (encoding.empty())
           {
@@ -568,7 +571,7 @@ namespace stcamera
 
           StApi::IStPixelFormatInfo *const p_pixelformat_info = 
               StApi::GetIStPixelFormatInfo(ePFNC);
-          if (p_pixelformat_info->IsMono() || p_pixelformat_info->IsBayer())
+          if (p_pixelformat_info->IsMono() || p_pixelformat_info->IsBayer() || p_pixelformat_info->IsColor())
           {
             //image data
             sensor_msgs::ImagePtr image(new sensor_msgs::Image);


### PR DESCRIPTION
Sentech SDK supports RGB format while this ros package does not. 
This minor tweak allows me to get RGB8 images in ros as sensor_msgs::Image from omron sentech cameras